### PR TITLE
Fixed formatting of heading (GitHub Markdown)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-#SDKMAN! Candidates Service
+# SDKMAN! Candidates Service
 
 This service supersedes the [Legacy Candidates Service](https://github.com/sdkman/sdkman-candidates-legacy).
 
-##Running Locally
+## Running Locally
 
 Make sure you have mongodb running locally or in a Docker Container:
 


### PR DESCRIPTION
GitHub Markdown requires a space after the heading symbol.

Before:
    <img width="541" alt="before" src="https://user-images.githubusercontent.com/1254039/33933638-a5e998cc-dff6-11e7-9536-c0d74325089e.png">

After:
    <img width="544" alt="after" src="https://user-images.githubusercontent.com/1254039/33933647-aab5e5d6-dff6-11e7-9876-123a96f0833e.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sdkman/sdkman-candidates/3)
<!-- Reviewable:end -->
