### PR TITLE
Add Semeru vendor

### DIFF
--- a/app/controllers/JavaListController.scala
+++ b/app/controllers/JavaListController.scala
@@ -77,6 +77,7 @@ class JavaListController @Inject() (versionRepo: VersionsRepository, cc: Control
     "mandrel" -> "Mandrel",
     "ms"      -> "Microsoft",
     "sapmchn" -> "SAP",
+    "sem"     -> "Semeru",
     "tem"     -> "Temurin",
     "trava"   -> "TravaOpenJDK",
     "zulu"    -> "Azul Zulu",

--- a/features/java_version_list_by_vendor.feature
+++ b/features/java_version_list_by_vendor.feature
@@ -34,6 +34,7 @@ Feature: Java Version List by Vendor
       | java      | 6.0.119-zulu     | zulu    | LINUX_64   | http://zulu.example.org/jdk-6.0.119.tar.gz         |
       | java      | 20.1.0.1-mandrel | mandrel | LINUX_64   | http://mandrel.example.org/mandrel-20.1.0.1.tar.gz |
       | java      | 11.0.9-ms        | ms      | LINUX_64   | http://ms.example.org/ms-11.0.9.tar.gz             |
+      | java      | 8.0.212-sem      | sem     | LINUX_64   | http://sem.example.org/sem-8.0.212.tar.gz          |
       | java      | 8.0.212-tem      | tem     | LINUX_64   | http://tem.example.org/tem-8.0.212.tar.gz          |
       | java      | 11.0.9-trava     | trava   | LINUX_64   | http://trava.example.org/trava-11.0.9.tar.gz       |
 
@@ -75,6 +76,7 @@ Feature: Java Version List by Vendor
     |               |     | 9.0.4        | open    |            | 9.0.4-open
     | Mandrel       |     | 20.1.0.1     | mandrel |            | 20.1.0.1-mandrel
     | Microsoft     |     | 11.0.9       | ms      |            | 11.0.9-ms
+    | Semeru        |     | 8.0.212      | sem     |            | 8.0.212-sem
     | Temurin       |     | 8.0.212      | tem     |            | 8.0.212-tem
     | TravaOpenJDK  |     | 11.0.9       | trava   |            | 11.0.9-trava
     | Unclassified  |     | 11.0.3       | none    | local only | 11.0.3-local


### PR DESCRIPTION
Currently, IBM Semeru binaries are available.
See https://developer.ibm.com/languages/java/semeru-runtimes/downloads
