### PR TITLE
Increase max URI length to 4k

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,7 +64,3 @@ releaseProcess := Seq[ReleaseStep](
   commitNextVersion,
   pushChanges
 )
-
-PlayKeys.devSettings := Seq(
-  "akka.http.parsing.max-uri-length" -> "4k"
-)

--- a/build.sbt
+++ b/build.sbt
@@ -64,3 +64,7 @@ releaseProcess := Seq[ReleaseStep](
   commitNextVersion,
   pushChanges
 )
+
+PlayKeys.devSettings := Seq(
+  "akka.http.parsing.max-uri-length" -> "4k"
+)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -4,6 +4,10 @@ play {
   filters.hosts.allowed = [".sdkman.io", "localhost"]
 }
 
+akka.http {
+    parsing.max-uri-length = 4k
+}
+
 application.version = "1.0.0-SNAPSHOT"
 
 mongo {


### PR DESCRIPTION
Doubles the max URI length (currently 2k).

Related to https://sdkman.slack.com/archives/CJTNQA94M/p1639954703084700.

