### PR TITLE
Add Tencent Kona JDKs

### DIFF
--- a/app/controllers/JavaListController.scala
+++ b/app/controllers/JavaListController.scala
@@ -95,6 +95,7 @@ class JavaListController @Inject() (
     "sapmchn" -> "SapMachine",
     "sem"     -> "Semeru",
     "tem"     -> "Temurin",
+    "tencent" -> "Kona",
     "trava"   -> "Trava",
     "zulu"    -> "Zulu",
     "zulufx"  -> "ZuluFX"

--- a/features/java_version_list_by_vendor.feature
+++ b/features/java_version_list_by_vendor.feature
@@ -21,6 +21,9 @@ Feature: Java Version List by Vendor
       | java      | 19.0.0-gln       | gln     | LINUX_64   | http://graal.example.org/graal-19.0.0.tar.gz       |
       | java      | 19.0.0-grl       | grl     | LINUX_64   | http://graal.example.org/graal-19.0.0.tar.gz       |
       | java      | 1.0.0-rc-16-grl  | grl     | LINUX_64   | http://graal.example.org/grl-1.0.0-rc16.tar.gz     |
+      | java      | 17.0.5-tencent   | tencent | LINUX_64   | http://tencent.example.org/jdk-17.0.5.tar.gz       |
+      | java      | 11.0.17-tencent  | tencent | LINUX_64   | http://tencent.example.org/jdk-11.0.17.tar.gz      |
+      | java      | 8.0.352-tencent  | tencent | LINUX_64   | http://tencent.example.org/jdk-8.0.352.tar.gz      |
       | java      | 13.ea.20-open    | open    | LINUX_64   | http://open.example.org/jdk-13.ea.20.tar.gz        |
       | java      | 12.0.1-open      | open    | LINUX_64   | http://open.example.org/jdk-12.0.1.tar.gz          |
       | java      | 11.0.3-open      | open    | LINUX_64   | http://open.example.org/jdk-11.0.3.tar.gz          |
@@ -70,6 +73,9 @@ Feature: Java Version List by Vendor
     |               |     | 11.0.3       | open    |            | 11.0.3-open
     |               |     | 10.0.2       | open    |            | 10.0.2-open
     |               |     | 9.0.4        | open    |            | 9.0.4-open
+    | Kona          |     | 17.0.5       | tencent |            | 17.0.5-tencent
+    |               |     | 11.0.17      | tencent |            | 11.0.17-tencent
+    |               |     | 8.0.352      | tencent |            | 8.0.352-tencent
     | Liberica NIK  |     | 19.0.0       | nik     |            | 19.0.0-nik
     | Mandrel       |     | 20.1.0.1     | mandrel |            | 20.1.0.1-mandrel
     | Microsoft     |     | 11.0.9       | ms      |            | 11.0.9-ms


### PR DESCRIPTION
Tencent Kona JDK is a downstream of OpenJDK.
It has three releases: [8], [11] and [17].

[8]:
<https://github.com/Tencent/TencentKona-8>

[11]:
<https://github.com/Tencent/TencentKona-11>

[17]:
<https://github.com/Tencent/TencentKona-17>