### PR TITLE
Add Huawei BiSheng JDKs

### DIFF
--- a/app/controllers/JavaListController.scala
+++ b/app/controllers/JavaListController.scala
@@ -83,6 +83,7 @@ class JavaListController @Inject() (
     "adpt"    -> "AdoptOpenJDK",
     "albba"   -> "Dragonwell",
     "amzn"    -> "Corretto",
+    "bisheng" -> "Huawei",
     "gln"     -> "Gluon",
     "graalce" -> "GraalVM CE",
     "graal"   -> "GraalVM Oracle",

--- a/features/java_version_list_by_vendor.feature
+++ b/features/java_version_list_by_vendor.feature
@@ -18,6 +18,8 @@ Feature: Java Version List by Vendor
       | java      | 8.0.212-albba    | albba   | LINUX_64   | http://albba.example.org/jdk-8.0.212.tar.gz        |
       | java      | 11.0.3-amzn      | amzn    | LINUX_64   | http://amzn.example.org/jdk-11.0.3.j9.tar.gz       |
       | java      | 8.0.212-amzn     | amzn    | LINUX_64   | http://amzn.example.org/jdk-8.0.212.tar.gz         |
+      | java      | 17.0.8-bisheng   | bisheng | LINUX_64   | http://bisheng.example.org/jdk-17.0.8.tar.gz       |
+      | java      | 8.0.382-bisheng  | bisheng | LINUX_64   | http://bisheng.example.org/jdk-8.0.382.tar.gz      |
       | java      | 19.0.0-gln       | gln     | LINUX_64   | http://graal.example.org/graal-19.0.0.tar.gz       |
       | java      | 17.0.7-graal     | graal   | LINUX_64   | http://graal.example.org/graal-17.0.7.tar.gz       |
       | java      | 17.0.7-graalce   | graalce | LINUX_64   | http://graal.example.org/graal-ce-17.0.7.tar.gz    |
@@ -66,6 +68,8 @@ Feature: Java Version List by Vendor
     | Gluon         |     | 19.0.0       | gln     |            | 19.0.0-gln
     | GraalVM CE    |     | 17.0.7       | graalce |            | 17.0.7-graalce
     | GraalVM Oracle|     | 17.0.7       | graal   |            | 17.0.7-graal
+    | Huawei        |     | 17.0.8       | bisheng |            | 17.0.8-bisheng
+    |               |     | 8.0.382      | bisheng |            | 8.0.382-bisheng
     | Java.net      |     | 13.ea.20     | open    | installed  | 13.ea.20-open
     |               |     | 12.0.1       | open    |            | 12.0.1-open
     |               |     | 11.0.3       | open    |            | 11.0.3-open


### PR DESCRIPTION
Huawei BiSheng JDK is a downstream of OpenJDK.
It has two releases: 8 and 17.
We want to support bisheng JDK on sdkman platform.
I submitted another PR, https://github.com/sdkman/sdkman-disco-integration/pull/15.