### PR TITLE
Add Huawei Bisheng to JDKs.

### DIFF
--- a/app/controllers/JavaListController.scala
+++ b/app/controllers/JavaListController.scala
@@ -83,7 +83,7 @@ class JavaListController @Inject() (
     "adpt"    -> "AdoptOpenJDK",
     "albba"   -> "Dragonwell",
     "amzn"    -> "Corretto",
-    "bsg"     -> "Huawei",
+    "bisheng" -> "Huawei",
     "gln"     -> "Gluon",
     "graalce" -> "GraalVM CE",
     "graal"   -> "GraalVM Oracle",

--- a/app/controllers/JavaListController.scala
+++ b/app/controllers/JavaListController.scala
@@ -83,7 +83,7 @@ class JavaListController @Inject() (
     "adpt"    -> "AdoptOpenJDK",
     "albba"   -> "Dragonwell",
     "amzn"    -> "Corretto",
-    "bsg" -> "Huawei",
+    "bsg"     -> "Huawei",
     "gln"     -> "Gluon",
     "graalce" -> "GraalVM CE",
     "graal"   -> "GraalVM Oracle",

--- a/app/controllers/JavaListController.scala
+++ b/app/controllers/JavaListController.scala
@@ -83,7 +83,7 @@ class JavaListController @Inject() (
     "adpt"    -> "AdoptOpenJDK",
     "albba"   -> "Dragonwell",
     "amzn"    -> "Corretto",
-    "bisheng" -> "Huawei",
+    "bsg" -> "Huawei",
     "gln"     -> "Gluon",
     "graalce" -> "GraalVM CE",
     "graal"   -> "GraalVM Oracle",

--- a/app/controllers/JavaListController.scala
+++ b/app/controllers/JavaListController.scala
@@ -83,6 +83,7 @@ class JavaListController @Inject() (
     "adpt"    -> "AdoptOpenJDK",
     "albba"   -> "Dragonwell",
     "amzn"    -> "Corretto",
+    "bisheng" -> "Huawei",
     "gln"     -> "Gluon",
     "graalce" -> "GraalVM CE",
     "graal"   -> "GraalVM Oracle",

--- a/features/java_version_list_by_vendor.feature
+++ b/features/java_version_list_by_vendor.feature
@@ -18,6 +18,9 @@ Feature: Java Version List by Vendor
       | java      | 8.0.212-albba    | albba   | LINUX_64   | http://albba.example.org/jdk-8.0.212.tar.gz        |
       | java      | 11.0.3-amzn      | amzn    | LINUX_64   | http://amzn.example.org/jdk-11.0.3.j9.tar.gz       |
       | java      | 8.0.212-amzn     | amzn    | LINUX_64   | http://amzn.example.org/jdk-8.0.212.tar.gz         |
+      | java      | 17.0.9-bisheng   | bisheng | LINUX_64   | http://bisheng.example.org/jdk-17.0.9.tar.gz          |
+      | java      | 11.0.21-bisheng  | bisheng | LINUX_64   | http://bisheng.example.org/jdk-11.0.21.tar.gz         |
+      | java      | 8.0.392-bisheng  | bisheng | LINUX_64   | http://bisheng.example.org/jdk-8.0.392.tar.gz         |
       | java      | 19.0.0-gln       | gln     | LINUX_64   | http://graal.example.org/graal-19.0.0.tar.gz       |
       | java      | 17.0.7-graal     | graal   | LINUX_64   | http://graal.example.org/graal-17.0.7.tar.gz       |
       | java      | 17.0.7-graalce   | graalce | LINUX_64   | http://graal.example.org/graal-ce-17.0.7.tar.gz    |
@@ -59,6 +62,9 @@ Feature: Java Version List by Vendor
     |               |     | 11.0.3.hs    | adpt    |            | 11.0.3.hs-adpt
     |               |     | 8.0.212.j9   | adpt    |            | 8.0.212.j9-adpt
     |               |     | 8.0.212.hs   | adpt    |            | 8.0.212.hs-adpt
+    | Huawei        |     | 17.0.9       | bisheng |            | 17.0.9-bisheng
+    |               |     | 11.0.21      | bisheng |            | 11.0.21-bisheng
+    |               |     | 8.0.392      | bisheng |            | 8.0.392-bisheng
     | Corretto      |     | 11.0.3       | amzn    |            | 11.0.3-amzn
     |               |     | 8.0.212      | amzn    |            | 8.0.212-amzn
     | Dragonwell    |     | 11.0.3       | albba   |            | 11.0.3-albba

--- a/features/java_version_list_by_vendor.feature
+++ b/features/java_version_list_by_vendor.feature
@@ -18,9 +18,9 @@ Feature: Java Version List by Vendor
       | java      | 8.0.212-albba    | albba   | LINUX_64   | http://albba.example.org/jdk-8.0.212.tar.gz        |
       | java      | 11.0.3-amzn      | amzn    | LINUX_64   | http://amzn.example.org/jdk-11.0.3.j9.tar.gz       |
       | java      | 8.0.212-amzn     | amzn    | LINUX_64   | http://amzn.example.org/jdk-8.0.212.tar.gz         |
-      | java      | 8.0.392-bisheng  | bisheng | LINUX_64   | http://bisheng.example.org/jdk-8.0.392.tar.gz      |
-      | java      | 11.0.21-bisheng  | bisheng | LINUX_64   | http://bisheng.example.org/jdk-11.0.21.tar.gz      |
       | java      | 17.0.9-bisheng   | bisheng | LINUX_64   | http://bisheng.example.org/jdk-17.0.9.tar.gz       |
+      | java      | 11.0.21-bisheng  | bisheng | LINUX_64   | http://bisheng.example.org/jdk-11.0.21.tar.gz      |
+      | java      | 8.0.392-bisheng  | bisheng | LINUX_64   | http://bisheng.example.org/jdk-8.0.392.tar.gz      |
       | java      | 19.0.0-gln       | gln     | LINUX_64   | http://graal.example.org/graal-19.0.0.tar.gz       |
       | java      | 17.0.7-graal     | graal   | LINUX_64   | http://graal.example.org/graal-17.0.7.tar.gz       |
       | java      | 17.0.7-graalce   | graalce | LINUX_64   | http://graal.example.org/graal-ce-17.0.7.tar.gz    |
@@ -62,9 +62,6 @@ Feature: Java Version List by Vendor
     |               |     | 11.0.3.hs    | adpt    |            | 11.0.3.hs-adpt
     |               |     | 8.0.212.j9   | adpt    |            | 8.0.212.j9-adpt
     |               |     | 8.0.212.hs   | adpt    |            | 8.0.212.hs-adpt
-    | Huawei        |     | 17.0.9       | bsg     |            | 17.0.9-bsg
-    |               |     | 11.0.21      | bsg     |            | 11.0.21-bsg
-    |               |     | 8.0.392      | bsg     |            | 8.0.392-bsg
     | Corretto      |     | 11.0.3       | amzn    |            | 11.0.3-amzn
     |               |     | 8.0.212      | amzn    |            | 8.0.212-amzn
     | Dragonwell    |     | 11.0.3       | albba   |            | 11.0.3-albba
@@ -72,6 +69,9 @@ Feature: Java Version List by Vendor
     | Gluon         |     | 19.0.0       | gln     |            | 19.0.0-gln
     | GraalVM CE    |     | 17.0.7       | graalce |            | 17.0.7-graalce
     | GraalVM Oracle|     | 17.0.7       | graal   |            | 17.0.7-graal
+    | Huawei        |     | 17.0.9       | bisheng |            | 17.0.9-bisheng
+    |               |     | 11.0.21      | bisheng |            | 11.0.21-bisheng
+    |               |     | 8.0.392      | bisheng |            | 8.0.392-bisheng
     | Java.net      |     | 13.ea.20     | open    | installed  | 13.ea.20-open
     |               |     | 12.0.1       | open    |            | 12.0.1-open
     |               |     | 11.0.3       | open    |            | 11.0.3-open

--- a/features/java_version_list_by_vendor.feature
+++ b/features/java_version_list_by_vendor.feature
@@ -18,9 +18,9 @@ Feature: Java Version List by Vendor
       | java      | 8.0.212-albba    | albba   | LINUX_64   | http://albba.example.org/jdk-8.0.212.tar.gz        |
       | java      | 11.0.3-amzn      | amzn    | LINUX_64   | http://amzn.example.org/jdk-11.0.3.j9.tar.gz       |
       | java      | 8.0.212-amzn     | amzn    | LINUX_64   | http://amzn.example.org/jdk-8.0.212.tar.gz         |
-      | java      | 17.0.9-bsg       | bsg     | LINUX_64   | http://bsg.example.org/bsg-17.0.9.tar.gz           |
-      | java      | 11.0.21-bsg      | bsg     | LINUX_64   | http://bsg.example.org/bsg-11.0.21.tar.gz          |
-      | java      | 8.0.392-bsg      | bsg     | LINUX_64   | http://bsg.example.org/bsg-8.0.392.tar.gz          |
+      | java      | 17.0.9-bsg       | bsg     | LINUX_64   | http://bsg.example.org/jdk-17.0.9.tar.gz           |
+      | java      | 11.0.21-bsg      | bsg     | LINUX_64   | http://bsg.example.org/jdk-11.0.21.tar.gz          |
+      | java      | 8.0.392-bsg      | bsg     | LINUX_64   | http://bsg.example.org/jdk-8.0.392.tar.gz          |
       | java      | 19.0.0-gln       | gln     | LINUX_64   | http://graal.example.org/graal-19.0.0.tar.gz       |
       | java      | 17.0.7-graal     | graal   | LINUX_64   | http://graal.example.org/graal-17.0.7.tar.gz       |
       | java      | 17.0.7-graalce   | graalce | LINUX_64   | http://graal.example.org/graal-ce-17.0.7.tar.gz    |

--- a/features/java_version_list_by_vendor.feature
+++ b/features/java_version_list_by_vendor.feature
@@ -18,9 +18,9 @@ Feature: Java Version List by Vendor
       | java      | 8.0.212-albba    | albba   | LINUX_64   | http://albba.example.org/jdk-8.0.212.tar.gz        |
       | java      | 11.0.3-amzn      | amzn    | LINUX_64   | http://amzn.example.org/jdk-11.0.3.j9.tar.gz       |
       | java      | 8.0.212-amzn     | amzn    | LINUX_64   | http://amzn.example.org/jdk-8.0.212.tar.gz         |
-      | java      | 17.0.9-bsg       | bsg     | LINUX_64   | http://bsg.example.org/jdk-17.0.9.tar.gz           |
-      | java      | 11.0.21-bsg      | bsg     | LINUX_64   | http://bsg.example.org/jdk-11.0.21.tar.gz          |
-      | java      | 8.0.392-bsg      | bsg     | LINUX_64   | http://bsg.example.org/jdk-8.0.392.tar.gz          |
+      | java      | 8.0.392-bisheng  | bisheng | LINUX_64   | http://bisheng.example.org/jdk-8.0.392.tar.gz      |
+      | java      | 17.0.9-bisheng   | bisheng | LINUX_64   | http://bisheng.example.org/jdk-17.0.9.tar.gz       |
+      | java      | 11.0.21-bisheng  | bisheng | LINUX_64   | http://bisheng.example.org/jdk-11.0.21.tar.gz      |
       | java      | 19.0.0-gln       | gln     | LINUX_64   | http://graal.example.org/graal-19.0.0.tar.gz       |
       | java      | 17.0.7-graal     | graal   | LINUX_64   | http://graal.example.org/graal-17.0.7.tar.gz       |
       | java      | 17.0.7-graalce   | graalce | LINUX_64   | http://graal.example.org/graal-ce-17.0.7.tar.gz    |

--- a/features/java_version_list_by_vendor.feature
+++ b/features/java_version_list_by_vendor.feature
@@ -18,9 +18,9 @@ Feature: Java Version List by Vendor
       | java      | 8.0.212-albba    | albba   | LINUX_64   | http://albba.example.org/jdk-8.0.212.tar.gz        |
       | java      | 11.0.3-amzn      | amzn    | LINUX_64   | http://amzn.example.org/jdk-11.0.3.j9.tar.gz       |
       | java      | 8.0.212-amzn     | amzn    | LINUX_64   | http://amzn.example.org/jdk-8.0.212.tar.gz         |
-      | java      | 17.0.9-bisheng   | bisheng | LINUX_64   | http://bisheng.example.org/jdk-17.0.9.tar.gz          |
-      | java      | 11.0.21-bisheng  | bisheng | LINUX_64   | http://bisheng.example.org/jdk-11.0.21.tar.gz         |
-      | java      | 8.0.392-bisheng  | bisheng | LINUX_64   | http://bisheng.example.org/jdk-8.0.392.tar.gz         |
+      | java      | 17.0.9-bsg       | bsg     | LINUX_64   | http://bsg.example.org/bsg-17.0.9.tar.gz           |
+      | java      | 11.0.21-bsg      | bsg     | LINUX_64   | http://bsg.example.org/bsg-11.0.21.tar.gz          |
+      | java      | 8.0.392-bsg      | bsg     | LINUX_64   | http://bsg.example.org/bsg-8.0.392.tar.gz          |
       | java      | 19.0.0-gln       | gln     | LINUX_64   | http://graal.example.org/graal-19.0.0.tar.gz       |
       | java      | 17.0.7-graal     | graal   | LINUX_64   | http://graal.example.org/graal-17.0.7.tar.gz       |
       | java      | 17.0.7-graalce   | graalce | LINUX_64   | http://graal.example.org/graal-ce-17.0.7.tar.gz    |
@@ -62,9 +62,9 @@ Feature: Java Version List by Vendor
     |               |     | 11.0.3.hs    | adpt    |            | 11.0.3.hs-adpt
     |               |     | 8.0.212.j9   | adpt    |            | 8.0.212.j9-adpt
     |               |     | 8.0.212.hs   | adpt    |            | 8.0.212.hs-adpt
-    | Huawei        |     | 17.0.9       | bisheng |            | 17.0.9-bisheng
-    |               |     | 11.0.21      | bisheng |            | 11.0.21-bisheng
-    |               |     | 8.0.392      | bisheng |            | 8.0.392-bisheng
+    | Huawei        |     | 17.0.9       | bsg     |            | 17.0.9-bsg
+    |               |     | 11.0.21      | bsg     |            | 11.0.21-bsg
+    |               |     | 8.0.392      | bsg     |            | 8.0.392-bsg
     | Corretto      |     | 11.0.3       | amzn    |            | 11.0.3-amzn
     |               |     | 8.0.212      | amzn    |            | 8.0.212-amzn
     | Dragonwell    |     | 11.0.3       | albba   |            | 11.0.3-albba

--- a/features/java_version_list_by_vendor.feature
+++ b/features/java_version_list_by_vendor.feature
@@ -19,8 +19,8 @@ Feature: Java Version List by Vendor
       | java      | 11.0.3-amzn      | amzn    | LINUX_64   | http://amzn.example.org/jdk-11.0.3.j9.tar.gz       |
       | java      | 8.0.212-amzn     | amzn    | LINUX_64   | http://amzn.example.org/jdk-8.0.212.tar.gz         |
       | java      | 8.0.392-bisheng  | bisheng | LINUX_64   | http://bisheng.example.org/jdk-8.0.392.tar.gz      |
-      | java      | 17.0.9-bisheng   | bisheng | LINUX_64   | http://bisheng.example.org/jdk-17.0.9.tar.gz       |
       | java      | 11.0.21-bisheng  | bisheng | LINUX_64   | http://bisheng.example.org/jdk-11.0.21.tar.gz      |
+      | java      | 17.0.9-bisheng   | bisheng | LINUX_64   | http://bisheng.example.org/jdk-17.0.9.tar.gz       |
       | java      | 19.0.0-gln       | gln     | LINUX_64   | http://graal.example.org/graal-19.0.0.tar.gz       |
       | java      | 17.0.7-graal     | graal   | LINUX_64   | http://graal.example.org/graal-17.0.7.tar.gz       |
       | java      | 17.0.7-graalce   | graalce | LINUX_64   | http://graal.example.org/graal-ce-17.0.7.tar.gz    |

--- a/test/steps/RestSteps.scala
+++ b/test/steps/RestSteps.scala
@@ -2,10 +2,10 @@ package steps
 
 import cucumber.api.scala.{EN, ScalaDsl}
 import org.scalatest.matchers.should.Matchers
+import play.api.libs.Files.logger
 import play.api.libs.json.Json
 import scalaj.http.Http
 import steps.World._
-import support.Mongo
 
 import scala.annotation.tailrec
 
@@ -61,6 +61,13 @@ class RestSteps extends ScalaDsl with EN with Matchers {
   }
 
   And("""^the response body is$""") { body: String =>
+    val responseBody = strip(response.body)
+    val strippedBody = body.stripMargin
+
+    if (responseBody != strippedBody) {
+      logger.error("The Body data is not what was expected, please check the body. \n >> Response Body:\n" + responseBody + "\n >> Expected Body:\n" + strippedBody)
+    }
+
     strip(response.body) shouldBe body.stripMargin
   }
 


### PR DESCRIPTION
Bisheng JDK is the open source version of Huawei JDK, which is customized based on OpenJDK. Huawei JDK runs on more than 500 Huawei products, and the R&D team has accumulated rich development experience and solved a number of difficult problems encountered in the actual operation of the business.
Bisheng JDK, as the downstream of OpenJDK, is a high-performance OpenJDK distribution that can be used in production environments. Bisheng JDK fixes some performance and stability problems encountered in Huawei's internal application scenarios, and makes performance optimization and stability enhancement on ARM architecture, which is more stable on ARM architecture and can get better performance in big data and other scenarios.
Bisheng JDK is dedicated to provide JAVA developers with a stable, reliable, high-performance and easy-to-tune JDK, as well as a better choice for users on ARM architecture.
Currently there are 3 major versions, [8](https://gitee.com/openeuler/bishengjdk-8), [11](https://gitee.com/openeuler/bishengjdk-11) and [17](https://gitee.com/openeuler/bishengjdk-17).