### PR TITLE
fix: harden State API integration before fronting the live CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 logs
 target
+.archon
 .idea
 .idea_modules
 .classpath

--- a/app/clients/StateApiImpl.scala
+++ b/app/clients/StateApiImpl.scala
@@ -2,6 +2,7 @@ package clients
 
 import cats.implicits.{catsSyntaxOptionId, none}
 import domain.Version
+import play.api.Logging
 import play.api.http.Status
 import play.api.libs.json.{JsError, JsSuccess}
 import utils.JsonConverters
@@ -33,7 +34,12 @@ trait StateApi {
 }
 
 @Singleton
-class StateApiImpl @Inject() (requestBuilder: RequestBuilder) extends StateApi with JsonConverters {
+class StateApiImpl @Inject() (requestBuilder: RequestBuilder)
+    extends StateApi
+    with JsonConverters
+    with Logging {
+
+  import StateApiImpl.ContractDrift
 
   override def findVisibleVersionsByCandidateAndPlatform(
       candidate: String,
@@ -43,12 +49,34 @@ class StateApiImpl @Inject() (requestBuilder: RequestBuilder) extends StateApi w
       .versionsByCandidatePlatformRequest(candidate, platform)
       .get()
       .flatMap { response =>
-        response.json.validate[List[Version]] match {
-          case JsSuccess(value, _) => Future.successful(value)
-          case JsError(e)          =>
-            // TODO: improve error handling
-            Future.failed(new RuntimeException(e.toString))
+        if (response.status == Status.OK)
+          response.json.validate[List[Version]] match {
+            case JsSuccess(value, _) => Future.successful(value)
+            // A 200 whose body is not Version[] is contract drift, not "no
+            // versions": surface it as a distinct failure the degrade path
+            // below deliberately does not swallow.
+            case JsError(e) =>
+              Future.failed(ContractDrift(candidate, platform, e.toString))
+          }
+        else {
+          // Any non-2xx degrades to an empty listing. Reachable today for the
+          // platforms the State API rejects with 400 (FREE_BSD/SUN_OS, behind
+          // `freebsd`/`sunos`), and covers 500/503 blips too.
+          logger.warn(
+            s"State API version listing for $candidate/$platform returned ${response.status}; degrading to empty list"
+          )
+          Future.successful(Seq.empty[Version])
         }
+      }
+      .recover {
+        // Timeouts and transport failures degrade as well; contract drift on a
+        // 200 body is intentionally excluded from the guard so it still fails.
+        case e if !e.isInstanceOf[ContractDrift] =>
+          logger.warn(
+            s"State API version listing for $candidate/$platform failed; degrading to empty list",
+            e
+          )
+          Seq.empty[Version]
       }
 
   override def findVersionByCandidateAndPlatform(
@@ -88,4 +116,15 @@ class StateApiImpl @Inject() (requestBuilder: RequestBuilder) extends StateApi w
         }
         else Future.successful(none)
       }
+}
+
+object StateApiImpl {
+
+  // A 200 listing response whose body does not parse as Version[] signals the
+  // State API contract has drifted. It is distinct from a "no versions"
+  // outcome, so the listing degrade path leaves this failure to propagate.
+  private final case class ContractDrift(candidate: String, platform: String, detail: String)
+      extends RuntimeException(
+        s"State API version listing for $candidate/$platform returned 200 with a body that is not Version[]: $detail"
+      )
 }

--- a/app/controllers/DefaultController.scala
+++ b/app/controllers/DefaultController.scala
@@ -16,16 +16,34 @@ class DefaultController @Inject() (
 
   def find(candidate: String): Action[AnyContent] = Action.async(parse.anyContent) { _ =>
     candidatesRepo.findCandidate(candidate).flatMap {
-      case None => Future.successful(BadRequest(""))
+      case None    => Future.successful(BadRequest(""))
       case Some(c) =>
-        val (platform, vendor) =
-          if (candidate == "java") ("LINUX_X64", Some("tem"))
-          else if (c.distribution == "UNIVERSAL") ("UNIVERSAL", None)
-          else ("LINUX_X64", None)
-        stateApi.findVersionByCandidateAndTag(candidate, "lts", platform, vendor).map {
-          case Some(version) => Ok(version.version)
-          case None          => BadRequest("")
+        // `candidates.distribution` labels are unreliable: some UNIVERSAL-labelled
+        // candidates host `lts` only at LINUX_X64 (and vice versa), and the State
+        // API filters platform exactly. So on a preferred-platform miss we retry
+        // once at the other platform; the preferred result wins when both hit.
+        // `java` is excluded — its `lts` needs distribution=TEMURIN and exists at
+        // neither platform without it — so it issues exactly one lookup, no fallback.
+        val (preferred, fallback, vendor) =
+          if (candidate == "java") ("LINUX_X64", None, Some("tem"))
+          else if (c.distribution == "UNIVERSAL") ("UNIVERSAL", Some("LINUX_X64"), None)
+          else ("LINUX_X64", Some("UNIVERSAL"), None)
+
+        lookup(candidate, preferred, vendor).flatMap {
+          case Some(version) => Future.successful(Ok(version.version))
+          case None =>
+            fallback match {
+              case Some(fallbackPlatform) =>
+                lookup(candidate, fallbackPlatform, vendor).map {
+                  case Some(version) => Ok(version.version)
+                  case None          => BadRequest("")
+                }
+              case None => Future.successful(BadRequest(""))
+            }
         }
     }
   }
+
+  private def lookup(candidate: String, platform: String, vendor: Option[String]) =
+    stateApi.findVersionByCandidateAndTag(candidate, "lts", platform, vendor)
 }

--- a/app/controllers/ValidationController.scala
+++ b/app/controllers/ValidationController.scala
@@ -17,9 +17,17 @@ class ValidationController @Inject() (
 
   def validate(candidate: String, versionVendor: String, platformId: String): Action[AnyContent] =
     Action.async(parse.anyContent) { _ =>
-      val versionParts = versionVendor.split("-")
-      val version      = versionParts(0)
-      val maybeVendor  = versionParts.lift(1)
+      // The `versionVendor` path segment carries an optional vendor suffix only
+      // for java (e.g. `21.0.5-tem`), where the vendor is the tail after the
+      // *last* `-`. For every other candidate the dash is part of the version
+      // itself (`groovy 6.0.0-alpha-1`, `sbt 2.0.0-RC13`, `kotlin 1.0.5-2`), so
+      // the whole segment is the version and there is no vendor.
+      val (version, maybeVendor) =
+        if (candidate == "java" && versionVendor.contains("-")) {
+          val idx = versionVendor.lastIndexOf("-")
+          (versionVendor.substring(0, idx), Some(versionVendor.substring(idx + 1)))
+        } else
+          (versionVendor, None)
       val maybeUniversalF =
         stateApi.findVersionByCandidateAndPlatform(
           candidate,

--- a/features/default.feature
+++ b/features/default.feature
@@ -23,6 +23,16 @@ Feature: Default Candidate Version
     When a request is made to /default/java
     Then a 200 status code is received
     And the response body is "21.0.5"
+    And the State API received exactly 1 tag lookup for java at platform LINUX_X64 with distribution TEMURIN
+    And the State API received exactly 1 tag lookup for java
+
+  Scenario: A Default Version for java is absent — a single lookup, no fallback
+    Given no default Version for java tag lts of platform LINUX_X64 on the remote service
+    When a request is made to /default/java
+    Then a 400 status code is received
+    And the response body is ""
+    And the State API received exactly 1 tag lookup for java at platform LINUX_X64 with distribution TEMURIN
+    And the State API received exactly 1 tag lookup for java
 
   Scenario: A Default Version is provided for a Platform Specific Candidate other than java
     Given the default Version on the remote service
@@ -70,3 +80,4 @@ Feature: Default Candidate Version
     When a request is made to /default/groovy
     Then a 400 status code is received
     And the response body is ""
+    And the State API received no requests

--- a/features/default.feature
+++ b/features/default.feature
@@ -32,8 +32,36 @@ Feature: Default Candidate Version
     Then a 200 status code is received
     And the response body is "7.2.0"
 
-  Scenario: A Default Version is requested but the State API has none
+  Scenario: A UNIVERSAL-labelled Candidate whose lts exists only at LINUX_X64 falls back
+    Given the default Version on the remote service
+      | candidate | tag | platform  | vendor | version |
+      | micronaut | lts | LINUX_X64 |        | 4.2.0   |
+    And no default Version for micronaut tag lts of platform UNIVERSAL on the remote service
+    When a request is made to /default/micronaut
+    Then a 200 status code is received
+    And the response body is "4.2.0"
+
+  Scenario: A UNIVERSAL-labelled Candidate hosting lts at both platforms resolves the preferred UNIVERSAL version
+    Given the default Version on the remote service
+      | candidate | tag | platform  | vendor | version |
+      | scala     | lts | UNIVERSAL |        | 2.13.0  |
+      | scala     | lts | LINUX_X64 |        | 2.12.0  |
+    When a request is made to /default/scala
+    Then a 200 status code is received
+    And the response body is "2.13.0"
+
+  Scenario: A non-UNIVERSAL Candidate whose lts exists only at UNIVERSAL falls back
+    Given the default Version on the remote service
+      | candidate | tag | platform  | vendor | version |
+      | cuba      | lts | UNIVERSAL |        | 7.3.0   |
+    And no default Version for cuba tag lts of platform LINUX_X64 on the remote service
+    When a request is made to /default/cuba
+    Then a 200 status code is received
+    And the response body is "7.3.0"
+
+  Scenario: A Default Version is requested but the State API has none at either platform
     Given no default Version for micronaut tag lts of platform UNIVERSAL on the remote service
+    And no default Version for micronaut tag lts of platform LINUX_X64 on the remote service
     When a request is made to /default/micronaut
     Then a 400 status code is received
     And the response body is ""

--- a/features/validation.feature
+++ b/features/validation.feature
@@ -106,3 +106,39 @@ Feature: Candidate Version Validation by Platform
     When I attempt validation at endpoint /validate/scala/2.12.0/exotic
     Then a 200 status code is received
     And the response body is "valid"
+
+  Scenario: Validation succeeds for a real dashed non-java version (groovy)
+    Given the Version on the remote service
+      | candidate | version       | vendor | platform  | url                                                    |
+      | groovy    | 6.0.0-alpha-1 |        | UNIVERSAL | http://dl/groovy/6.0.0-alpha-1/groovy-6.0.0-alpha-1.zip |
+    And no Version for groovy 6.0.0-alpha-1  of platform LINUX_X64 on the remote service
+    When I attempt validation at endpoint /validate/groovy/6.0.0-alpha-1/linuxx64
+    Then a 200 status code is received
+    And the response body is "valid"
+
+  Scenario: Validation succeeds for a real dashed non-java version (sbt)
+    Given the Version on the remote service
+      | candidate | version    | vendor | platform  | url                                        |
+      | sbt       | 2.0.0-RC13 |        | UNIVERSAL | http://dl/sbt/2.0.0-RC13/sbt-2.0.0-RC13.zip |
+    And no Version for sbt 2.0.0-RC13  of platform LINUX_X64 on the remote service
+    When I attempt validation at endpoint /validate/sbt/2.0.0-RC13/linuxx64
+    Then a 200 status code is received
+    And the response body is "valid"
+
+  Scenario: Validation succeeds for a real dashed non-java version (kotlin)
+    Given the Version on the remote service
+      | candidate | version | vendor | platform  | url                                          |
+      | kotlin    | 1.0.5-2 |        | UNIVERSAL | http://dl/kotlin/1.0.5-2/kotlin-1.0.5-2.zip |
+    And no Version for kotlin 1.0.5-2  of platform LINUX_X64 on the remote service
+    When I attempt validation at endpoint /validate/kotlin/1.0.5-2/linuxx64
+    Then a 200 status code is received
+    And the response body is "valid"
+
+  Scenario: Validation still splits the java vendor from the last dash
+    Given the Version on the remote service
+      | candidate | version | vendor | platform  | url                                         |
+      | java      | 21.0.5  | tem    | LINUX_X64 | http://dl/java/21.0.5-tem/jdk-21.0.5.tar.gz |
+    And no Version for java 21.0.5 tem of platform UNIVERSAL on the remote service
+    When I attempt validation at endpoint /validate/java/21.0.5-tem/linuxx64
+    Then a 200 status code is received
+    And the response body is "valid"

--- a/features/versions.feature
+++ b/features/versions.feature
@@ -51,3 +51,16 @@ Feature: Versions
     When a request is made to /candidates/jmc/linuxx64/versions/all
     Then a 200 status code is received
     And the response body is "8.3.0,9.1.1"
+
+  Scenario: Degrade a State API listing rejection to an empty list rather than a 500
+    And no Versions for scala of platform UNIVERSAL on the remote service
+    And the remote service rejects scala of platform FREE_BSD with status 400
+    When a request is made to /candidates/scala/freebsd/versions/all
+    Then a 200 status code is received
+    And the response body is ""
+
+  Scenario: A malformed 200 listing body is contract drift, not "no versions"
+    And no Versions for scala of platform UNIVERSAL on the remote service
+    And the remote service returns a malformed body for scala of platform LINUX_X64
+    When a request is made to /candidates/scala/linuxx64/versions/all
+    Then a 500 status code is received

--- a/test/clients/StateApiImplSpec.scala
+++ b/test/clients/StateApiImplSpec.scala
@@ -3,11 +3,13 @@ package clients
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import com.typesafe.config.ConfigFactory
 import domain.Version
 import org.scalatest.BeforeAndAfterAll
+import org.scalatest.Inspectors.forAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Millis, Seconds, Span}
@@ -139,6 +141,77 @@ class StateApiImplSpec
       stateApi
         .findVersionByCandidateAndTag("missing", "lts", "UNIVERSAL", None)
         .futureValue shouldBe None
+    }
+  }
+
+  "findVisibleVersionsByCandidateAndPlatform" should {
+
+    def stubListing(candidate: String, platform: String)(
+        response: ResponseDefinitionBuilder
+    ): Unit =
+      stub(
+        get(urlPathEqualTo(s"/versions/$candidate"))
+          .withQueryParam("platform", equalTo(platform))
+          .willReturn(response)
+      )
+
+    "map a 200 body to the parsed Version list" in {
+      val versions = List(
+        Version("groovy", "4.0.0", "UNIVERSAL", "https://dl/groovy/4.0.0.zip", Some(true), None),
+        Version("groovy", "4.0.1", "UNIVERSAL", "https://dl/groovy/4.0.1.zip", Some(true), None)
+      )
+      stubListing("groovy", "UNIVERSAL")(
+        aResponse().withStatus(200).withBody(Json.toJson(versions).toString)
+      )
+
+      stateApi
+        .findVisibleVersionsByCandidateAndPlatform("groovy", "UNIVERSAL")
+        .futureValue shouldBe versions
+    }
+
+    "map a 200 empty array to an empty Seq" in {
+      stubListing("groovy", "UNIVERSAL")(aResponse().withStatus(200).withBody("[]"))
+
+      stateApi
+        .findVisibleVersionsByCandidateAndPlatform("groovy", "UNIVERSAL")
+        .futureValue shouldBe empty
+    }
+
+    // A State API blip or an unrecognised platform (400 for FREE_BSD/SUN_OS)
+    // must degrade to an empty listing, never surface as a 500 to the CLI.
+    forAll(Seq(400, 500, 503)) { status =>
+      s"degrade a $status listing read to an empty Seq" in {
+        stubListing("groovy", "FREE_BSD")(aResponse().withStatus(status))
+
+        stateApi
+          .findVisibleVersionsByCandidateAndPlatform("groovy", "FREE_BSD")
+          .futureValue shouldBe empty
+      }
+    }
+
+    "degrade a timeout to an empty Seq" in {
+      // The request timeout is 1500ms (RequestBuilder); a longer delay forces a
+      // transport-level failure the client degrades rather than propagates.
+      stubListing("groovy", "UNIVERSAL")(
+        aResponse().withStatus(200).withBody("[]").withFixedDelay(3000)
+      )
+
+      stateApi
+        .findVisibleVersionsByCandidateAndPlatform("groovy", "UNIVERSAL")
+        .futureValue shouldBe empty
+    }
+
+    // Contract drift is not "no versions": a 200 whose body is not Version[]
+    // must still fail so the divergence is visible, not silently swallowed.
+    "fail on a malformed 200 body" in {
+      stubListing("groovy", "UNIVERSAL")(
+        aResponse().withStatus(200).withBody("""{"unexpected":"shape"}""")
+      )
+
+      stateApi
+        .findVisibleVersionsByCandidateAndPlatform("groovy", "UNIVERSAL")
+        .failed
+        .futureValue shouldBe a[RuntimeException]
     }
   }
 }

--- a/test/steps/DbSteps.scala
+++ b/test/steps/DbSteps.scala
@@ -132,6 +132,23 @@ class DbSteps extends ScalaDsl with EN with Matchers {
       )
   }
 
+  And("""^the remote service rejects (.*) of platform (.*) with status (\d+)$""") {
+    (candidate: String, platform: String, status: Int) =>
+      StateApiStubs.stubVersionsErrorForCandidateAndPlatform(
+        candidate = candidate,
+        platform = platform,
+        status = status
+      )
+  }
+
+  And("""^the remote service returns a malformed body for (.*) of platform (.*)$""") {
+    (candidate: String, platform: String) =>
+      StateApiStubs.stubMalformedVersionsForCandidateAndPlatform(
+        candidate = candidate,
+        platform = platform
+      )
+  }
+
   And("""^the Version on the remote service$""") { versionsTable: DataTable =>
     val version = versionsTable.toVersions.head
     StateApiStubs.stubVersionForCandidateAndPlatform(

--- a/test/steps/RestSteps.scala
+++ b/test/steps/RestSteps.scala
@@ -1,5 +1,13 @@
 package steps
 
+import com.github.tomakehurst.wiremock.client.WireMock.{
+  anyRequestedFor,
+  anyUrl,
+  equalTo,
+  getRequestedFor,
+  urlPathMatching,
+  verify
+}
 import cucumber.api.scala.{EN, ScalaDsl}
 import org.scalatest.AppendedClues
 import org.scalatest.matchers.should.Matchers
@@ -58,6 +66,31 @@ class RestSteps extends ScalaDsl with EN with Matchers with AppendedClues {
 
   And("""^the response body is "(.*)"$""") { body: String =>
     response.body shouldBe body
+  }
+
+  // Request-journal assertions against the shared WireMock State API stub (port
+  // 8080, journal reset per scenario in Env.Before). These pin call counts the
+  // response-only assertions cannot see: a regression giving `/default/java` a
+  // fallback, or hitting the State API before the unknown-candidate check, still
+  // returns the same status/body but issues a different number of requests.
+  And("""^the State API received no requests$""") { () =>
+    verify(0, anyRequestedFor(anyUrl()))
+  }
+
+  And("""^the State API received exactly (\d+) tag lookups? for (\S+)$""") {
+    (count: Int, candidate: String) =>
+      verify(count, getRequestedFor(urlPathMatching(s"/versions/$candidate/tags/.*")))
+  }
+
+  And(
+    """^the State API received exactly (\d+) tag lookups? for (\S+) at platform (\S+) with distribution (\S+)$"""
+  ) { (count: Int, candidate: String, platform: String, distribution: String) =>
+    verify(
+      count,
+      getRequestedFor(urlPathMatching(s"/versions/$candidate/tags/.*"))
+        .withQueryParam("platform", equalTo(platform))
+        .withQueryParam("distribution", equalTo(distribution))
+    )
   }
 
   And("""^the response body is$""") { body: String =>

--- a/test/support/StateApiStubs.scala
+++ b/test/support/StateApiStubs.scala
@@ -37,6 +37,37 @@ object StateApiStubs extends JsonConverters {
         )
     )
 
+  // Mirrors a non-2xx from the real State API listing read — e.g. the 400 it
+  // returns for platforms it does not recognise (FREE_BSD/SUN_OS, behind
+  // `freebsd`/`sunos`), or a 500/503 blip. The client degrades these to an
+  // empty listing rather than surfacing a 500.
+  def stubVersionsErrorForCandidateAndPlatform(
+      candidate: String,
+      platform: String,
+      status: Int
+  ): Unit =
+    stubFor(
+      get(urlPathEqualTo(s"/versions/$candidate"))
+        .withQueryParam("platform", equalTo(platform))
+        .willReturn(aResponse().withStatus(status))
+    )
+
+  // A 200 whose body is not Version[] — contract drift. The client must still
+  // fail on this rather than treat it as "no versions".
+  def stubMalformedVersionsForCandidateAndPlatform(
+      candidate: String,
+      platform: String
+  ): Unit =
+    stubFor(
+      get(urlPathEqualTo(s"/versions/$candidate"))
+        .withQueryParam("platform", equalTo(platform))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withBody("""{"unexpected":"shape"}""")
+        )
+    )
+
   def stubVersionForCandidateAndPlatform(
       candidate: String,
       version: String,


### PR DESCRIPTION
## What & why

Three defects surfaced reviewing [PR #71](https://github.com/sdkman/sdkman-candidates/pull/71#pullrequestreview-4878315974) that must be fixed before this service fronts the live CLI. Each is a case where the switch from direct Mongo reads to State API HTTP calls narrowed behaviour the CLI relies on — turning a working read into a `400`/`500`/`invalid`. Spec: [`specs/state-api-hardening.md`](specs/state-api-hardening.md) (amends `state-api-default-version.md`).

1. **A State API blip returns `500` to the CLI (`sdk list`).** The version-listing read parsed the body regardless of status, so any non-2xx, timeout, or transport failure became an unrecovered `500`. Reachable today: `freebsd`/`sunos` map to platforms the State API rejects with `400`.
2. **`/default` returns `400` when `lts` isn't at the labelled platform.** The tag-lookup platform came from the unreliable `candidates.distribution` label; 14 live candidates are labelled `UNIVERSAL` but host `lts` only at `LINUX_X64`, resolving `400` where the old read returned a version.
3. **`/validate` rejects real dashed versions.** The identifier was split on the *first* `-`, treating the tail as a vendor — valid only for java. Real versions (`groovy 6.0.0-alpha-1`, `sbt 2.0.0-RC13`, `kotlin 1.0.5-2`) validated `invalid`, blocking install.

The State API is consumed as-is throughout — no endpoint or schema changes; every fix lives in this service's client/controller code.

## Changes

- **Defect #1 — degrade a failed listing read (`471d329`):** `findVisibleVersionsByCandidateAndPlatform` now gates body parsing on `200 OK` and `.recover`s any non-2xx / timeout / transport failure to an empty `Seq`, logging candidate + platform + cause. A `200` whose body isn't `Version[]` still fails the future (contract drift, via a private `ContractDrift` marker excluded from the degrade guard).
- **Defect #2 — platform fallback for `/default` (`c9f983c`):** `DefaultController.find` retries the `lts` tag lookup once at the fallback platform on a preferred-platform miss, per the spec matrix (labelled `UNIVERSAL`→`LINUX_X64`, else→`UNIVERSAL`), preferred winning when both hit. `java` still issues exactly one `distribution=TEMURIN` lookup with no fallback; unknown candidate still `400` with zero State API calls.
- **Defect #3 — last-dash, java-only vendor parse (`9ad55db`):** `ValidationController.validate` treats the whole identifier as the version for non-java candidates and only splits the suffix after the *last* `-` as the vendor for `java`.
- **Coverage (`6072bdf`, `471d329`, `c9f983c`, `9ad55db`):** WireMock stub builders for non-2xx and malformed listing bodies; unit + Cucumber coverage for each defect; and request-journal assertions pinning `/default/java`'s single `distribution=TEMURIN` lookup (with a new java-miss scenario that trips if a fallback regresses in) and the unknown-candidate zero-call path.
- **Chore (`8cd3603`):** ignore the local `archon` working directory.

## Review

The PR #71 review found three defects; all three are closed by this branch (commits `471d329`, `c9f983c`, `9ad55db`).

A follow-up review gap (`## Review gaps`, 2026-08-07) noted the `/default` call-count properties were behaviourally correct but not regression-protected: a spurious java fallback, or a State API call made before the unknown-candidate check, passed every existing scenario because an unstubbed fallback miss is indistinguishable from no fallback. Closed by `6072bdf`, which adds WireMock `verify` assertions and a dedicated java-miss scenario. Spec is now fully satisfied; no open gaps remain.

Out of scope (documented in the spec): State API endpoint/schema changes, correcting the `candidates.distribution` labels in Mongo (the #2 fallback is the durable fix), and the `/versions/all` unknown-candidate / global re-sort items.

## Test plan

From this submodule root, with ports **8080** (WireMock) and **9000** (Play `TestServer`) free — the local end-game compose stack holds both, so stop `sdkman-endgame-state-api-1` and `sdkman-endgame-candidates-1` first:

```
bash ./sbt test
bash ./sbt scalafmtCheck Test/scalafmtCheck
```

Both are green on this branch: `./sbt test` **170/170** (Cucumber 118 + ScalaTest 52) and the scalafmt gate clean. HTTP calls are stubbed via WireMock — no live State API is required. The malformed-body `/candidates/scala/linuxx64/versions/all` scenario intentionally logs a `ContractDrift` stack trace and asserts `500` — that output is expected, not a failure.

Key behavioural checks:
- A `500`/`503`/`400`/timeout listing read yields an empty list; `/candidates/:c/freebsd/versions/all` returns `2xx`; a malformed `200` still fails.
- A `UNIVERSAL`-labelled candidate with `lts` only at `LINUX_X64` resolves `200`; both-platform resolves to the preferred version; `/default/java` issues one `distribution=TEMURIN` lookup.
- `/validate/groovy/6.0.0-alpha-1/<platform>` resolves `valid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
