### PR TITLE
fix(default): suffix java default with the vendor shortcode

### DIFF
--- a/app/controllers/DefaultController.scala
+++ b/app/controllers/DefaultController.scala
@@ -30,12 +30,12 @@ class DefaultController @Inject() (
           else ("LINUX_X64", Some("UNIVERSAL"), None)
 
         lookup(candidate, preferred, vendor).flatMap {
-          case Some(version) => Future.successful(Ok(version.version))
+          case Some(version) => Future.successful(Ok(publicId(version.version, vendor)))
           case None =>
             fallback match {
               case Some(fallbackPlatform) =>
                 lookup(candidate, fallbackPlatform, vendor).map {
-                  case Some(version) => Ok(version.version)
+                  case Some(version) => Ok(publicId(version.version, vendor))
                   case None          => BadRequest("")
                 }
               case None => Future.successful(BadRequest(""))
@@ -46,4 +46,7 @@ class DefaultController @Inject() (
 
   private def lookup(candidate: String, platform: String, vendor: Option[String]) =
     stateApi.findVersionByCandidateAndTag(candidate, "lts", platform, vendor)
+
+  private def publicId(version: String, vendor: Option[String]): String =
+    vendor.fold(version)(shortcode => s"$version-$shortcode")
 }

--- a/features/default.feature
+++ b/features/default.feature
@@ -22,7 +22,7 @@ Feature: Default Candidate Version
       | java      | lts | LINUX_X64 | tem     | 21.0.5  |
     When a request is made to /default/java
     Then a 200 status code is received
-    And the response body is "21.0.5"
+    And the response body is "21.0.5-tem"
     And the State API received exactly 1 tag lookup for java at platform LINUX_X64 with distribution TEMURIN
     And the State API received exactly 1 tag lookup for java
 


### PR DESCRIPTION
## Problem

`GET /default/java` returned the bare State API version (`25.0.4`) instead of the installable public identifier (`25.0.4-tem`). Because the CLI resolves `/default/java` to install java when no version is given, `sdk install java` aborted with *"java 25.0.4 is not available"* — the bare version validates `invalid` and the broker 404s it (java needs its distribution). Regression surfaced when the Candidates service cut over from the Mongo `candidates.default` read (which stored the suffixed token) to the State API `lts` tag lookup (which returns the bare `version`).

## Fix

`DefaultController` reconstructs the public identifier by appending the query vendor shortcode for java (`25.0.4` + `tem` → `25.0.4-tem`). `vendor` is `Some` only for java, so every other candidate keeps its bare version unchanged.

## Tests

The `default.feature` java scenario asserted the bare `21.0.5`, which had codified the bug — it now asserts the installable `21.0.5-tem`. Cucumber suite green (52/52), scalafmt clean.