### PR TITLE
fix(list): reconstruct java identifiers from bare version + vendor

### DIFF
--- a/app/controllers/DefaultController.scala
+++ b/app/controllers/DefaultController.scala
@@ -30,12 +30,12 @@ class DefaultController @Inject() (
           else ("LINUX_X64", Some("UNIVERSAL"), None)
 
         lookup(candidate, preferred, vendor).flatMap {
-          case Some(version) => Future.successful(Ok(publicId(version.version, vendor)))
+          case Some(version) => Future.successful(Ok(version.identifier))
           case None =>
             fallback match {
               case Some(fallbackPlatform) =>
                 lookup(candidate, fallbackPlatform, vendor).map {
-                  case Some(version) => Ok(publicId(version.version, vendor))
+                  case Some(version) => Ok(version.identifier)
                   case None          => BadRequest("")
                 }
               case None => Future.successful(BadRequest(""))
@@ -46,7 +46,4 @@ class DefaultController @Inject() (
 
   private def lookup(candidate: String, platform: String, vendor: Option[String]) =
     stateApi.findVersionByCandidateAndTag(candidate, "lts", platform, vendor)
-
-  private def publicId(version: String, vendor: Option[String]): String =
-    vendor.fold(version)(shortcode => s"$version-$shortcode")
 }

--- a/app/controllers/VersionsController.scala
+++ b/app/controllers/VersionsController.scala
@@ -22,6 +22,6 @@ class VersionsController @Inject() (
       for {
         universalVersions <- universalVersionsF
         platformVersions  <- platformVersionsF
-      } yield Ok((universalVersions ++ platformVersions).map(_.version).mkString(","))
+      } yield Ok((universalVersions ++ platformVersions).map(_.identifier).mkString(","))
     }
 }

--- a/app/domain/Version.scala
+++ b/app/domain/Version.scala
@@ -7,4 +7,6 @@ case class Version(
     url: String,
     visible: Option[Boolean],
     vendor: Option[String]
-)
+) {
+  def identifier: String = vendor.fold(version)(shortcode => s"$version-$shortcode")
+}

--- a/app/rendering/VersionItemListBuilder.scala
+++ b/app/rendering/VersionItemListBuilder.scala
@@ -6,7 +6,7 @@ trait VersionItemListBuilder {
 
   val MinCountThreshold: Int
 
-  def available(v: Seq[Version]): Seq[String] = v.map(_.version)
+  def available(v: Seq[Version]): Seq[String] = v.map(_.identifier)
 
   def local(installed: Option[String]): Seq[String] = installed.toList.flatMap(_.split(","))
 

--- a/features/java_version_list_by_vendor.feature
+++ b/features/java_version_list_by_vendor.feature
@@ -14,32 +14,32 @@ Feature: Java Version List by Vendor
     # exercises the State-API-hosted distributions.
     Given the Versions
       | candidate | version          | vendor  | platform  | url                                                |
-      | java      | 11.0.3-amzn      | amzn    | LINUX_X64 | http://amzn.example.org/jdk-11.0.3.j9.tar.gz       |
-      | java      | 8.0.212-amzn     | amzn    | LINUX_X64 | http://amzn.example.org/jdk-8.0.212.tar.gz         |
-      | java      | 17.0.9-bisheng   | bisheng | LINUX_X64 | http://bisheng.example.org/jdk-17.0.9.tar.gz       |
-      | java      | 11.0.21-bisheng  | bisheng | LINUX_X64 | http://bisheng.example.org/jdk-11.0.21.tar.gz      |
-      | java      | 8.0.392-bisheng  | bisheng | LINUX_X64 | http://bisheng.example.org/jdk-8.0.392.tar.gz      |
-      | java      | 17.0.7-graal     | graal   | LINUX_X64 | http://graal.example.org/graal-17.0.7.tar.gz       |
-      | java      | 17.0.7-graalce   | graalce | LINUX_X64 | http://graal.example.org/graal-ce-17.0.7.tar.gz    |
-      | java      | 11.0.8-jbr       | jbr     | LINUX_X64 | http://jbr.example.org/jbr-11.0.8.tar.gz           |
-      | java      | 17.0.7-jbr       | jbr     | LINUX_X64 | http://jbr.example.org/jbr-17.0.7.tar.gz           |
-      | java      | 20.1.0.1-mandrel | mandrel | LINUX_X64 | http://mandrel.example.org/mandrel-20.1.0.1.tar.gz |
-      | java      | 11.0.9-ms        | ms      | LINUX_X64 | http://ms.example.org/ms-11.0.9.tar.gz             |
-      | java      | 19.0.0-nik       | nik     | LINUX_X64 | http://nik.example.org/nik-19.0.0.tar.gz           |
-      | java      | 13.ea.20-open    | open    | LINUX_X64 | http://open.example.org/jdk-13.ea.20.tar.gz        |
-      | java      | 12.0.1-open      | open    | LINUX_X64 | http://open.example.org/jdk-12.0.1.tar.gz          |
-      | java      | 11.0.3-open      | open    | LINUX_X64 | http://open.example.org/jdk-11.0.3.tar.gz          |
-      | java      | 10.0.2-open      | open    | LINUX_X64 | http://open.example.org/jdk-10.0.2.tar.gz          |
-      | java      | 9.0.4-open       | open    | LINUX_X64 | http://open.example.org/jdk-9.0.4.tar.gz           |
-      | java      | 11.0.9-oracle    | oracle  | LINUX_X64 | http://oracle.example.org/oracle-11.0.9.tar.gz     |
-      | java      | 8.0.212-sem      | sem     | LINUX_X64 | http://sem.example.org/sem-8.0.212.tar.gz          |
-      | java      | 8.0.212-tem      | tem     | LINUX_X64 | http://tem.example.org/tem-8.0.212.tar.gz          |
-      | java      | 17.0.5-kona      | kona    | LINUX_X64 | http://kona.example.org/jdk-17.0.5.tar.gz          |
-      | java      | 11.0.17-kona     | kona    | LINUX_X64 | http://kona.example.org/jdk-11.0.17.tar.gz         |
-      | java      | 8.0.352-kona     | kona    | LINUX_X64 | http://kona.example.org/jdk-8.0.352.tar.gz         |
-      | java      | 12.0.1-zulu      | zulu    | LINUX_X64 | http://zulu.example.org/jdk-12.0.1.tar.gz          |
-      | java      | 11.0.3-zulu      | zulu    | LINUX_X64 | http://zulu.example.org/jdk-11.0.3.tar.gz          |
-      | java      | 8.0.212-zulu     | zulu    | LINUX_X64 | http://zulu.example.org/jdk-8.0.212.tar.gz         |
+      | java      | 11.0.3           | amzn    | LINUX_X64 | http://amzn.example.org/jdk-11.0.3.j9.tar.gz       |
+      | java      | 8.0.212          | amzn    | LINUX_X64 | http://amzn.example.org/jdk-8.0.212.tar.gz         |
+      | java      | 17.0.9           | bisheng | LINUX_X64 | http://bisheng.example.org/jdk-17.0.9.tar.gz       |
+      | java      | 11.0.21          | bisheng | LINUX_X64 | http://bisheng.example.org/jdk-11.0.21.tar.gz      |
+      | java      | 8.0.392          | bisheng | LINUX_X64 | http://bisheng.example.org/jdk-8.0.392.tar.gz      |
+      | java      | 17.0.7           | graal   | LINUX_X64 | http://graal.example.org/graal-17.0.7.tar.gz       |
+      | java      | 17.0.7           | graalce | LINUX_X64 | http://graal.example.org/graal-ce-17.0.7.tar.gz    |
+      | java      | 11.0.8           | jbr     | LINUX_X64 | http://jbr.example.org/jbr-11.0.8.tar.gz           |
+      | java      | 17.0.7           | jbr     | LINUX_X64 | http://jbr.example.org/jbr-17.0.7.tar.gz           |
+      | java      | 20.1.0.1         | mandrel | LINUX_X64 | http://mandrel.example.org/mandrel-20.1.0.1.tar.gz |
+      | java      | 11.0.9           | ms      | LINUX_X64 | http://ms.example.org/ms-11.0.9.tar.gz             |
+      | java      | 19.0.0           | nik     | LINUX_X64 | http://nik.example.org/nik-19.0.0.tar.gz           |
+      | java      | 13.ea.20         | open    | LINUX_X64 | http://open.example.org/jdk-13.ea.20.tar.gz        |
+      | java      | 12.0.1           | open    | LINUX_X64 | http://open.example.org/jdk-12.0.1.tar.gz          |
+      | java      | 11.0.3           | open    | LINUX_X64 | http://open.example.org/jdk-11.0.3.tar.gz          |
+      | java      | 10.0.2           | open    | LINUX_X64 | http://open.example.org/jdk-10.0.2.tar.gz          |
+      | java      | 9.0.4            | open    | LINUX_X64 | http://open.example.org/jdk-9.0.4.tar.gz           |
+      | java      | 11.0.9           | oracle  | LINUX_X64 | http://oracle.example.org/oracle-11.0.9.tar.gz     |
+      | java      | 8.0.212          | sem     | LINUX_X64 | http://sem.example.org/sem-8.0.212.tar.gz          |
+      | java      | 8.0.212          | tem     | LINUX_X64 | http://tem.example.org/tem-8.0.212.tar.gz          |
+      | java      | 17.0.5           | kona    | LINUX_X64 | http://kona.example.org/jdk-17.0.5.tar.gz          |
+      | java      | 11.0.17          | kona    | LINUX_X64 | http://kona.example.org/jdk-11.0.17.tar.gz         |
+      | java      | 8.0.352          | kona    | LINUX_X64 | http://kona.example.org/jdk-8.0.352.tar.gz         |
+      | java      | 12.0.1           | zulu    | LINUX_X64 | http://zulu.example.org/jdk-12.0.1.tar.gz          |
+      | java      | 11.0.3           | zulu    | LINUX_X64 | http://zulu.example.org/jdk-11.0.3.tar.gz          |
+      | java      | 8.0.212          | zulu    | LINUX_X64 | http://zulu.example.org/jdk-8.0.212.tar.gz         |
 
     And the current Version is 12.0.1-zulu
     And the installed Versions 8.0.202-zulu,12.0.1-zulu,13.ea.20-open,11.0.3-local
@@ -94,7 +94,7 @@ Feature: Java Version List by Vendor
   Scenario: An orphaned local version is displayed
     Given the Versions
       | candidate | version     | vendor | platform  | url                                       |
-      | java      | 10.0.2-open | open   | LINUX_X64 | http://open.example.org/jdk-10.0.2.tar.gz |
+      | java      | 10.0.2      | open   | LINUX_X64 | http://open.example.org/jdk-10.0.2.tar.gz |
 
     And the installed Versions 10.0.2-open,10.0.1-open
     When a request is made to /candidates/java/linuxx64/versions/list
@@ -122,7 +122,7 @@ Feature: Java Version List by Vendor
   Scenario: An unclassified local version is displayed
     Given the Versions
       | candidate | version     | vendor | platform  | url                                       |
-      | java      | 10.0.2-open | open   | LINUX_X64 | http://open.example.org/jdk-10.0.2.tar.gz |
+      | java      | 10.0.2      | open   | LINUX_X64 | http://open.example.org/jdk-10.0.2.tar.gz |
 
     And the installed Versions 10.0.2-open,10.0.1-local,8.0.212-vendor,8.0.212-xyz
     When a request is made to /candidates/java/linuxx64/versions/list
@@ -152,7 +152,7 @@ Feature: Java Version List by Vendor
   Scenario: No local or orphaned versions are displayed
     Given the Versions
       | candidate | version     | vendor | platform  | url                                       |
-      | java      | 10.0.2-open | open   | LINUX_X64 | http://open.example.org/jdk-10.0.2.tar.gz |
+      | java      | 10.0.2      | open   | LINUX_X64 | http://open.example.org/jdk-10.0.2.tar.gz |
 
     And the installed Versions 10.0.2-open
     When a request is made to /candidates/java/linuxx64/versions/list

--- a/features/version_list_by_platform.feature
+++ b/features/version_list_by_platform.feature
@@ -9,14 +9,14 @@ Feature: Version List by Platform
 
     And the Versions
       | candidate | version     | vendor | platform    | url                                                                                       |
-      | java      | 8u111-open  | open   | LINUX_X64   | http://download.oracle.com/otn-pub/java/jdk/8u111-b14/jdk-8u111-linux-x64.tar.gz          |
-      | java      | 8u121-open  | open   | LINUX_X64   | http://download.oracle.com/otn-pub/java/jdk/8u121-b14/jdk-8u121-linux-x64.tar.gz          |
-      | java      | 8u131-open  | open   | LINUX_X64   | http://download.oracle.com/otn-pub/java/jdk/8u131-b14/jdk-8u131-linux-x64.tar.gz          |
-      | java      | 9ea163-open | open   | LINUX_X64   | http://download.java.net/java/jdk9/archive/163/binaries/jdk-9-ea+163_linux-x64_bin.tar.gz |
-      | java      | 8u131-open  | open   | MAC_X64     | http://download.oracle.com/otn-pub/java/jdk/8u131-b14/jdk-8u131-osx-x64.tar.gz            |
-      | java      | 9ea163-open | open   | MAC_X64     | http://download.java.net/java/jdk9/archive/163/binaries/jdk-9-ea+163_osx-x64_bin.tar.gz   |
-      | java      | 8u111-open  | open   | WINDOWS_X64 | http://download.oracle.com/otn-pub/java/jdk/8u111-b14/jdk-8u111-windows-x64.tar.gz        |
-      | java      | 8u121-open  | open   | WINDOWS_X64 | http://download.oracle.com/otn-pub/java/jdk/8u121-b14/jdk-8u121-windows-x64.tar.gz        |
+      | java      | 8u111       | open   | LINUX_X64   | http://download.oracle.com/otn-pub/java/jdk/8u111-b14/jdk-8u111-linux-x64.tar.gz          |
+      | java      | 8u121       | open   | LINUX_X64   | http://download.oracle.com/otn-pub/java/jdk/8u121-b14/jdk-8u121-linux-x64.tar.gz          |
+      | java      | 8u131       | open   | LINUX_X64   | http://download.oracle.com/otn-pub/java/jdk/8u131-b14/jdk-8u131-linux-x64.tar.gz          |
+      | java      | 9ea163      | open   | LINUX_X64   | http://download.java.net/java/jdk9/archive/163/binaries/jdk-9-ea+163_linux-x64_bin.tar.gz |
+      | java      | 8u131       | open   | MAC_X64     | http://download.oracle.com/otn-pub/java/jdk/8u131-b14/jdk-8u131-osx-x64.tar.gz            |
+      | java      | 9ea163      | open   | MAC_X64     | http://download.java.net/java/jdk9/archive/163/binaries/jdk-9-ea+163_osx-x64_bin.tar.gz   |
+      | java      | 8u111       | open   | WINDOWS_X64 | http://download.oracle.com/otn-pub/java/jdk/8u111-b14/jdk-8u111-windows-x64.tar.gz        |
+      | java      | 8u121       | open   | WINDOWS_X64 | http://download.oracle.com/otn-pub/java/jdk/8u121-b14/jdk-8u121-windows-x64.tar.gz        |
       | scala     | 2.12.6      |        | UNIVERSAL   | http://dl/scala/2.12.0/scala-2.12.0.zip                                                   |
       | micronaut | 2.0.0       |        | LINUX_X64   | http://dl/micronaut/2.0.0/mn-1.3.5-linux.zip                                              |
       | micronaut | 2.0.0       |        | MAC_X64     | http://dl/micronaut/2.0.0/mn-1.3.5-osx.zip                                                |

--- a/features/version_list_by_visibility.feature
+++ b/features/version_list_by_visibility.feature
@@ -6,9 +6,9 @@ Feature: Version List by Visibility
       | java      | Java | Java Platform | 17.0.0-tem | https://adoptium.net | PLATFORM_SPECIFIC |
     And the Versions
       | candidate | version       | vendor | platform  | url                                                                                                                  | visible |
-      | java      | 8.0.222.hs-tem | tem   | LINUX_X64 | https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u222b10.tar.gz | true    |
-      | java      | 8.0.272.hs-tem | tem   | LINUX_X64 | https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u272-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u272b10.tar.gz |         |
-      | java      | 8.0.275.hs-tem | tem   | LINUX_X64 | https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u275-b01/OpenJDK8U-jdk_x64_linux_hotspot_8u275b01.tar.gz | false   |
+      | java      | 8.0.222.hs     | tem   | LINUX_X64 | https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u222-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u222b10.tar.gz | true    |
+      | java      | 8.0.272.hs     | tem   | LINUX_X64 | https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u272-b10/OpenJDK8U-jdk_x64_linux_hotspot_8u272b10.tar.gz |         |
+      | java      | 8.0.275.hs     | tem   | LINUX_X64 | https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u275-b01/OpenJDK8U-jdk_x64_linux_hotspot_8u275b01.tar.gz | false   |
     When a request is made to /candidates/java/linuxx64/versions/list
     Then a 200 status code is received
     And the response body is

--- a/features/versions.feature
+++ b/features/versions.feature
@@ -13,7 +13,7 @@ Feature: Versions
     And no Versions for java of platform UNIVERSAL on the remote service
     When a request is made to /candidates/java/linuxx64/versions/all
     Then a 200 status code is received
-    And the response body is "8u111,8u121,8u131,9ea163"
+    And the response body is "8u111-open,8u121-open,8u131-open,9ea163-open"
 
   Scenario: Find all Versions for a given Universal Candidate
     Given the Candidate
@@ -42,11 +42,11 @@ Feature: Versions
   Scenario: Find all Versions for a Candidate registered as UNIVERSAL but hosting platform-specific Versions
     Given the Candidate
       | candidate | name | description         | default    | websiteUrl              | distribution |
-      | jmc       | JMC  | JDK Mission Control | 9.1.1-zulu | https://jdk.java.net/jmc | UNIVERSAL    |
+      | jmc       | JMC  |                     | 9.1.1-zulu | https://jdk.java.net/jmc | UNIVERSAL    |
     And the Versions
       | candidate | version | vendor | platform  | url                                                    |
-      | jmc       | 8.3.0   | zulu   | LINUX_X64 | https://downloads/jmc/8.3.0/jmc-8.3.0-linux-x64.tar.gz |
-      | jmc       | 9.1.1   | zulu   | LINUX_X64 | https://downloads/jmc/9.1.1/jmc-9.1.1-linux-x64.tar.gz |
+      | jmc       | 8.3.0   |        | LINUX_X64 | https://downloads/jmc/8.3.0/jmc-8.3.0-linux-x64.tar.gz |
+      | jmc       | 9.1.1   |        | LINUX_X64 | https://downloads/jmc/9.1.1/jmc-9.1.1-linux-x64.tar.gz |
     And no Versions for jmc of platform UNIVERSAL on the remote service
     When a request is made to /candidates/jmc/linuxx64/versions/all
     Then a 200 status code is received

--- a/test/domain/VersionSpec.scala
+++ b/test/domain/VersionSpec.scala
@@ -1,0 +1,23 @@
+package domain
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class VersionSpec extends AnyWordSpec with Matchers {
+
+  private def version(v: String, vendor: Option[String]) =
+    Version("java", v, "LINUX_X64", "http://url", Some(true), vendor)
+
+  "Version.identifier" should {
+
+    "append the vendor shortcode when present" in {
+      version("25.0.4", Some("tem")).identifier shouldBe "25.0.4-tem"
+      version("8.0.272.hs", Some("amzn")).identifier shouldBe "8.0.272.hs-amzn"
+    }
+
+    "return the bare version when there is no vendor" in {
+      version("5.0.8", None).identifier shouldBe "5.0.8"
+      version("6.0.0-alpha-1", None).identifier shouldBe "6.0.0-alpha-1"
+    }
+  }
+}


### PR DESCRIPTION
## Problem

The State API stores java as a **bare** version (`26.0.2`) plus a separate distribution, but the CLI needs the suffixed public identifier (`26.0.2-amzn`). Two endpoints emitted the bare version:

- **`sdk list java`** (`JavaListController` → `VersionItemListBuilder.available`) — the *Identifier* column showed `26.0.2` instead of `26.0.2-amzn`, and installed/current markers stopped matching (the CLI sends suffixed ids).
- **`versions/all`** (`VersionsController`) — the CSV / TAB-completion source returned bare ids, so `sdk install java 26.0.2` validates **invalid**.

Same class as the earlier `/default/java` regression, in the code paths that fix missed.

## Fix

Centralise the reconstruction as **`Version.identifier`** (`vendor.fold(version)(v => s"$version-$v")`) and apply it at every java-identifier emitter — the list builder, `versions/all`, and `/default` (replacing its ad-hoc helper). Non-java candidates have no vendor, so they keep their bare version unchanged.

## Tests

The feature fixtures stored the suffix **in the version field** (`8u111-open`), which is unrealistic vs the State API (bare + distribution) and masked the bug. Made them realistic (bare version + vendor) across the java list/versions features so they now genuinely exercise the reconstruction, blanked a stray non-java vendor (`jmc`), and added `VersionSpec`. Cucumber 54/54 + unit green.

A companion live regression suite (in the control-plane repo) covers this across 10 real java distributions.